### PR TITLE
Fixes missing empty line preceding bullet point lists

### DIFF
--- a/vignettes/01_scate-shortcourse.Rmd
+++ b/vignettes/01_scate-shortcourse.Rmd
@@ -26,6 +26,7 @@ You would like to understand the evolution of morphological traits in a group, a
 You begin by querying ‘Siluriformes’ in the Phenoscape KB faceted browsing page (http://beta.phenoscape.org/#/facet).  You immediately see the scope of the data:
 
 From left to right across the top tabs, for ‘Siluriformes’:
+
 - There are 4,537 unique phenotypes
 - There are 292,356 taxon annotations 
 - There are 1,452 siluriform taxa with data in the KB 
@@ -132,6 +133,7 @@ The above returns 29 species of ictalurid catfishes and 123 anatomical entities 
 You will need to go the [Phenoscape KB] to view the supporting states, i.e., the source data upon which inferences were made or those that were directly asserted.  
 
 For example, in the returned OntoTrace matrix (see ‘m’ in Global Environment (row 10)) the pelvic fin is scored as present for *Ictalurus australis*. Enter these data into the faceted browsing interface:
+
 - Anatomical entity = ‘pelvic fin’
 - Quality = ‘present’
 - Taxon = ‘Ictalurus australis’


### PR DESCRIPTION
This is a fix-up of #7.